### PR TITLE
Improved wordpress detection

### DIFF
--- a/plugins/scanners.py
+++ b/plugins/scanners.py
@@ -11,7 +11,7 @@ def find_cms(url):
         res = requests.get(url, headers=headers)
     except:
         return "unknown"
-    if "wp-content/themes/" in res.text:
+    if "wp-content/themes/" in res.text or "wordpress" in res.text:
         return "wordpress"
     elif "Drupal.settings" in res.text:
         return "drupal"

--- a/plugins/scanners.py
+++ b/plugins/scanners.py
@@ -11,7 +11,7 @@ def find_cms(url):
         res = requests.get(url, headers=headers)
     except:
         return "unknown"
-    if "wp-content/themes/" in res.text or "wordpress" in res.text:
+    if "wp-content/themes/" in res.text or "powered by WordPress" in res.text:
         return "wordpress"
     elif "Drupal.settings" in res.text:
         return "drupal"


### PR DESCRIPTION
Searching for 'wp-content/themes/' is not the only way of determining the presence of WordPress. 
The script should also search for 'powered by WordPress'.