### PR TITLE
Add a flag to use pre-installed scanners

### DIFF
--- a/plugins/scanners.py
+++ b/plugins/scanners.py
@@ -3,6 +3,8 @@ from subprocess import check_output, CalledProcessError, STDOUT
 import requests
 from fake_useragent import UserAgent
 
+# Toggle to use tools installed in the system path instead of using from plugins
+USE_PREINSTALLED_TOOLS = False
 
 def find_cms(url):
     try:
@@ -37,10 +39,10 @@ def droopescan(url):
     print(f"[INFO] droopescan scanning URL: {url}")
     if not url.endswith("/"):
         url += "/"
-    wp_scan = ['droopescan', 'scan', 'drupal', '-u',
+    droope_scan = ['droopescan', 'scan', 'drupal', '-u',
                url, '-t', '8', '-o', 'json', '-e', 'a',
                '--hide-progressbar']
-    return cmd_runner(wp_scan)
+    return cmd_runner(droope_scan)
 
 
 def update_wpscan():
@@ -62,7 +64,10 @@ def vbscan(url):
     print(f"[INFO] vbscan scanning URL: {url}")
     if not url.endswith("/"):
         url += "/"
-    vb_scan = ['perl', 'plugins/vbscan/vbscan.pl', url]
+    if USE_PREINSTALLED_TOOLS:
+        vb_scan = ['vbscan', url]
+    else:
+        vb_scan = ['perl', 'plugins/vbscan/vbscan.pl', url]
     return cmd_runner(vb_scan)
 
 
@@ -70,5 +75,8 @@ def joomscan(url):
     print(f"[INFO] joomscan scanning URL: {url}")
     if not url.endswith("/"):
         url += "/"
-    jm_scan = ['perl', 'plugins/joomscan/joomscan.pl', '--url', url, '-ec']
+    if USE_PREINSTALLED_TOOLS:
+        jm_scan = ['joomscan', '--url', url, '-ec']
+    else:
+        jm_scan = ['perl', 'plugins/joomscan/joomscan.pl', '--url', url, '-ec']
     return cmd_runner(jm_scan)


### PR DESCRIPTION
## Why?

Some distributions like [BlackArch](https://blackarch.org/tools.html) already have tools like joomscan & vbscan pre-installed. So, I added a flag to optionally use the pre-installed tool instead of relying on the submodules in plugins directory.

This will make it packaging for BlackArch a little bit more easier (have to do minimal sed) to get it to work with pre-installed tools.

